### PR TITLE
fix insales tags

### DIFF
--- a/lib/liquid/tags/content_for.rb
+++ b/lib/liquid/tags/content_for.rb
@@ -27,15 +27,15 @@ module Liquid
     SYNTAX      = /([\S]+)/
     SYNTAX_HELP = "Syntax Error in tag 'content_for' - Valid syntax: content_for 'name'"
 
-    def initialize(tag_name, markup, tokens)
-      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
-      @name = Variable.new $1
+    def initialize(tag_name, markup, parse_context)
+      # same as #blank? in Rails
+      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ /[^[:space:]]/
+      @name = Variable.new(markup, parse_context)
       super
     end
 
     def render(context)
-      result = ''
-      context.stack { result = render_all @nodelist, context }
+      result = super
       key = @name.render context
       context.content_for[key] = result
       ''

--- a/lib/liquid/tags/layout.rb
+++ b/lib/liquid/tags/layout.rb
@@ -3,12 +3,12 @@ module Liquid
   #
   #
   class Tag::Layout < Tag
-    SYNTAX      = /(.*)/
     SYNTAX_HELP = "Syntax Error in 'layout' - Valid syntax: layout value"
 
-    def initialize(tag_name, markup, tokens)
-      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
-      @name = Variable.new $1
+    def initialize(tag_name, markup, parse_context)
+      # same as #blank? in Rails
+      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ /[^[:space:]]/
+      @name = Variable.new(markup, parse_context)
       super
     end
 

--- a/lib/liquid/tags/yield.rb
+++ b/lib/liquid/tags/yield.rb
@@ -21,11 +21,12 @@ module Liquid
   class Tag::Yield < Tag
     SYNTAX      = /(.*)/
     SYNTAX_HELP = "Syntax Error in 'yield' - Valid syntax: yield ['name']"
+    # This is key that will be used if you haven't specified one
     EMPTY_YIELD_KEY = '_rendered_template_'
 
-    def initialize(tag_name, markup, tokens)
+    def initialize(tag_name, markup, parse_context)
       raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
-      @what = !$1.empty? && Variable.new($1)
+      @what = !markup.empty? && Variable.new(markup, parse_context)
       super
     end
 


### PR DESCRIPTION
Этот ПР просто для ревью кода.
Когда закончу с основной веткой с тестами, этот коммит туда войдет.

Главная сложность - тег content_for, т.к. он сломался прям очень сильно из-за того, что Shopify декомпозировали класс `Block`. Но наши тесты он, вроде, проходит.