### PR TITLE
Патчи insales ребэйзнутые на официальный мастер

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -67,7 +67,7 @@ module Liquid
 
         if include?(Enumerable)
           blacklist += Enumerable.public_instance_methods
-          blacklist -= [:sort, :count, :first, :min, :max, :include?]
+          blacklist -= [:sort, :count, :first, :min, :max]
         end
 
         whitelist = [:to_liquid] + (public_instance_methods - blacklist)

--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -56,6 +56,10 @@ module Liquid
 
     alias_method :[], :invoke_drop
 
+    def to_json(options = {})
+      {}.to_json
+    end
+
     # Check for method existence without invoking respond_to?, which creates symbols
     def self.invokable?(method_name)
       invokable_methods.include?(method_name.to_s)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -103,7 +103,7 @@ module Liquid
 
     def strip_html(input)
       empty = ''.freeze
-      input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
+      input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty).gsub('&nbsp;'.freeze, ' '.freeze)
     end
 
     # Remove all newlines from the string

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -201,6 +201,7 @@ module Liquid
 
     # Replace occurrences of a string with another
     def replace(input, string, replacement = ''.freeze)
+      return input if !string || !replacement
       input.to_s.gsub(string.to_s, replacement.to_s)
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -213,11 +213,13 @@ module Liquid
 
     # remove a substring
     def remove(input, string)
+      return input if !string
       input.to_s.gsub(string.to_s, ''.freeze)
     end
 
     # remove the first occurrences of a substring
     def remove_first(input, string)
+      return input if !string
       input.to_s.sub(string.to_s, ''.freeze)
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -207,6 +207,7 @@ module Liquid
 
     # Replace the first occurrences of a string with another
     def replace_first(input, string, replacement = ''.freeze)
+      return input if !string || !replacement
       input.to_s.sub(string.to_s, replacement.to_s)
     end
 

--- a/lib/liquid/tags/content_for.rb
+++ b/lib/liquid/tags/content_for.rb
@@ -1,0 +1,65 @@
+module Liquid
+  # The content_for method allows you to insert content into a yield block in your layout.
+  # You only use content_for to insert content in named yields.
+  #
+  # It saves rendered text between tags into context's _content_for_ field,
+  # which is a hash.
+  #
+  # You need explicitly set _context.content_for[Liquid::Tag::Yield::EMPTY_YIELD_KEY]_
+  # to rendered string. There is shortcut _context.content_for_layout=_
+  # that sets it and _context['content_for_layout_']_.
+  #
+  # In your layout:
+  #  <title>{% yield 'title' %}</title>
+  #  <body>{% yield %}</body>
+  #
+  # In the view:
+  #  {% content_for 'title' %} The title {% end_content_for %}
+  #  The body
+  #
+  #
+  # Will produce:
+  #  <title>The title</title>
+  #  <body>The body</body>
+  #
+  #
+  class Tag::ContentFor < Block
+    SYNTAX      = /([\S]+)/
+    SYNTAX_HELP = "Syntax Error in tag 'content_for' - Valid syntax: content_for 'name'"
+
+    def initialize(tag_name, markup, tokens)
+      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
+      @name = Variable.new $1
+      super
+    end
+
+    def render(context)
+      result = ''
+      context.stack { result = render_all @nodelist, context }
+      key = @name.render context
+      context.content_for[key] = result
+      ''
+    end
+
+    def block_delimiter
+      "end_#{block_name}"
+    end
+
+    def blank?
+      true
+    end
+  end
+
+  class Context
+    def content_for
+      @content_for ||= {}
+    end
+
+    def content_for_layout=(value)
+      content_for[Liquid::Tag::Yield::EMPTY_YIELD_KEY] =
+        self['content_for_layout'] = value
+    end
+  end
+
+  Template.register_tag 'content_for', Tag::ContentFor
+end

--- a/lib/liquid/tags/layout.rb
+++ b/lib/liquid/tags/layout.rb
@@ -1,0 +1,26 @@
+module Liquid
+  # {% layout 'smth' %} sets context.layout = smth
+  #
+  #
+  class Tag::Layout < Tag
+    SYNTAX      = /(.*)/
+    SYNTAX_HELP = "Syntax Error in 'layout' - Valid syntax: layout value"
+
+    def initialize(tag_name, markup, tokens)
+      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
+      @name = Variable.new $1
+      super
+    end
+
+    def render(context)
+      context.layout = @name.render context
+      ''
+    end
+  end
+
+  class Context
+    attr_accessor :layout
+  end
+
+  Template.register_tag 'layout', Tag::Layout
+end

--- a/lib/liquid/tags/yield.rb
+++ b/lib/liquid/tags/yield.rb
@@ -1,0 +1,46 @@
+module Liquid
+  # Within the context of a layout, yield identifies a section where content
+  # from the view should be inserted. 
+  # The simplest way to use this is to have a single yield, into which the
+  # entire contents of the view currently being rendered is inserted.
+  #
+  # In your layout:
+  #  <title>{% yield 'title' %}</title>
+  #  <body>{% yield %}</body>
+  #
+  # In the view:
+  #  {% content_for 'title' %} The title {% end_content_for %}
+  #  The body    
+  #
+  #
+  # Will produce:
+  #  <title>The title</title>
+  #  <body>The body</body>
+  #
+  #
+  class Tag::Yield < Tag
+    SYNTAX      = /(.*)/
+    SYNTAX_HELP = "Syntax Error in 'yield' - Valid syntax: yield ['name']"
+    EMPTY_YIELD_KEY = '_rendered_template_'
+
+    def initialize(tag_name, markup, tokens)
+      raise SyntaxError.new(SYNTAX_HELP) unless markup =~ SYNTAX
+      @what = Variable.new $1
+      super
+    end
+
+    def render(context)
+      key = @what.render context
+      key = EMPTY_YIELD_KEY if !key || key.empty?
+      res = context.content_for[key]
+      if !res || res.empty?
+        ''
+      elsif res.is_a?(Array)
+        res = res.first
+      end
+      res
+    end
+  end
+
+  Template.register_tag 'yield', Tag::Yield
+end

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -54,6 +54,8 @@ module Liquid
       else
         if obj.respond_to?(:to_number)
           obj.to_number
+        elsif obj.respond_to?(:to_f)
+          BigDecimal.new(obj.to_f.to_s)
         else
           0
         end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -377,6 +377,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal 'a a a', @filters.remove_first("a a a a", 'a ')
     assert_equal ' 1 1 1', @filters.remove_first("1 1 1 1", 1)
     assert_template_result 'a a a', "{{ 'a a a a' | remove_first: 'a ' }}"
+    assert_equal 'a a a a', @filters.remove_first("a a a a", nil)
+    assert_equal 'a a a a', @filters.remove("a a a a", nil)
   end
 
   def test_pipes_in_string_arguments

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -367,6 +367,8 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
     assert_equal 'a a a a', @filters.replace("a a a a", 'a', nil)
     assert_equal 'a a a a', @filters.replace("a a a a", nil, 'a')
+    assert_equal 'a a a a', @filters.replace_first("a a a a", 'a', nil)
+    assert_equal 'a a a a', @filters.replace_first("a a a a", nil, 'a')
   end
 
   def test_remove

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -365,6 +365,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2)
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2)
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
+    assert_equal 'a a a a', @filters.replace("a a a a", 'a', nil)
+    assert_equal 'a a a a', @filters.replace("a a a a", nil, 'a')
   end
 
   def test_remove

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -177,6 +177,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal 'test', @filters.strip_html("<div\nclass='multiline'>test</div>")
     assert_equal 'test', @filters.strip_html("<!-- foo bar \n test -->test")
     assert_equal '', @filters.strip_html(nil)
+    assert_equal 'a  b', @filters.strip_html('a&nbsp;&nbsp;b')
   end
 
   def test_join

--- a/test/liquid/tags/content_for_yield_test.rb
+++ b/test/liquid/tags/content_for_yield_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class IfElseTagTest < Test::Unit::TestCase
+  include Liquid
+
+  def test_content_for
+    tmpl = Liquid::Template.parse <<-LIQUID
+main
+{% content_for 'head' %}begin{% end_content_for %}
+{% content_for 'footer' %}end{% end_content_for %}
+    LIQUID
+    context = Liquid::Context.new
+    body = tmpl.render context
+    assert_equal "main\n\n\n", body
+    context.content_for_layout = body
+    assert_template_result body, '{% yield %}', context
+    assert_template_result '', '{% yield "undefined" %}', context
+    assert_template_result "begin #{body} end", '{% yield "head" %} {% yield %} {% yield "footer" %}', context
+  end
+
+  def test_content_for_with_nested_tags
+    tmpl = Liquid::Template.parse <<-LIQUID
+main
+{% content_for 'head' %}{% for i in (1..5) %}{{i}}{% endfor %}{% end_content_for %}
+{% content_for 'footer' %}{{ 'END' | downcase }}{% end_content_for %}
+    LIQUID
+    context = Liquid::Context.new
+    body = tmpl.render context
+    assert_equal "main\n\n\n", body
+    context.content_for_layout = body
+    assert_template_result body, '{% yield %}', context
+    assert_template_result '', '{% yield "undefined" %}', context
+    assert_template_result "12345 #{body} end", '{% yield "head" %} {% yield %} {% yield "footer" %}', context
+  end
+
+  def test_external_content_for
+    context = Liquid::Context.new
+    context.content_for_layout = 'body'
+    context.content_for['head']     = 'begin'
+    context.content_for['footer']   = 'end'
+    assert_template_result "begin body end", '{% yield "head" %} {% yield %} {% yield "footer" %}', context
+  end
+
+  def test_expressions
+    context = Liquid::Context.new
+    context['var'] = 'test'
+    assert_template_result '', '{% content_for var %}a{% end_content_for %}', context
+    assert_equal context.content_for['test'], 'a'
+    assert_template_result 'a', '{% yield var %}', context
+    assert_template_result 'a', "{% yield 'test' %}", context
+  end
+
+  def test_syntax
+    assert_raise Liquid::SyntaxError do
+      Liquid::Template.parse '{% content_for %}{% end_content_for %}'
+    end
+  end
+end

--- a/test/liquid/tags/layout_test.rb
+++ b/test/liquid/tags/layout_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class LayoutTest < Test::Unit::TestCase
+  include Liquid
+
+  def test_set_layout
+    tmpl = Liquid::Template.parse '{% layout "test" %}'
+    context = Liquid::Context.new
+    assert_equal context.layout, nil
+    assert_equal '', tmpl.render(context)
+    assert_equal context.layout, 'test'
+  end
+
+  def test_set_layout_with_variable
+    tmpl = Liquid::Template.parse '{% layout var %}'
+    context = Liquid::Context.new
+    context['var'] = 'test'
+    assert_equal context.layout, nil
+    assert_equal '', tmpl.render(context)
+    assert_equal context.layout, 'test'
+  end
+end


### PR DESCRIPTION
Не включен только комит с удалением i18n

Патчи которые могут быть удалены:
- remove/remove_first

В мастере исправили ошибку, но отличается поведение:
- `"ab" | replace "a", nil` в мастере возвращает `b`, у нас - входную строку без изменений.
- При делении на 0 текст ошибки у нас "division by 0", в мастере "divided by 0" (комит с  патчем сюда не включен)

Наши патчи без аналогов:
- замена nbsp в strip_html на пробелы
- удаление `include?` из разрешенным методов дропа (непонятно пока зачем так было сделано).
- дефолтный Drop#to_json
-  использование to_f для конвертации в число, если объект на него отвечает.